### PR TITLE
Revert footer year change in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 # Introduction to Git and GitHub
 
 ## Simple Interest Calculator
@@ -13,4 +14,7 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2023 XYZ, Inc._
+_© 2022 XYZ, Inc._
+=======
+# coding-project-template
+ parent of d8324ad (Update README.md)


### PR DESCRIPTION
This PR reverts commit d8324ad which updated the footer year from 2022 to 2023.