### PR TITLE
Revert footer typo: change year back to 2022Fix footer typo: update year from 2022 to 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
Reverting the previous typo fix in README.md that updated the year to 2023. Now it is set back to 2022