### PR TITLE
Fix typo: update yRevert typo fix: restore footer year to 2022ear in footer to 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._
+


### PR DESCRIPTION
This PR reverts the previous change that updated the footer year to 2023, restoring it back to 2022.
