### PR TITLE
Revert copyright year change - practice exercircise

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,7 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_©2023  XYZ, Inc._
+
+
+


### PR DESCRIPTION
This PR reverts the copyright year change as a practice exercise.
     
     Changes:
     - Reverts footer from "2023 XYZ, Inc." back to "2022 XYZ, Inc."
     
     This is part of the final project submission.