### PR TITLE
Corrige error tipográfico: cambia 2022 por 2023 en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
Se corrigió el error tipográfico en el archivo README.md, cambiando "2022 XYZ, Inc." por "2023 XYZ, Inc." en la rama bug-fix-typo.