### PR TITLE
Reverted footer year back to 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._
 

--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2023 XYZ, Inc._
+_© 2022 XYZ, Inc._
+


### PR DESCRIPTION
This pull request reverts the previous commit that updated the footer year from 2022 to 2023. The footer now correctly shows 2022 XYZ, Inc.
