### PR TITLE
Revert footer year from 2023 back to 2022 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
This reverts the footer line in README from "2023 XYZ, Inc." back to "2022 XYZ, Inc." as requested in the lab instructions.
