### PR TITLE
Update copyright year to 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
Updated the copyright year to avoid confusion. 

Please show that 2023 is the year, not 2022. 

Updated the copyright year to avoid confusion.

Please show that 2023 is the year, not 2022.

This is part of my final project on Coursera called Final Project: Part 2-Git CLI.