### PR TITLE
Revert footer year change to 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._

--- a/forked-repo.txt
+++ b/forked-repo.txt
@@ -1,0 +1,2 @@
+curl -s https://api.github.com/repos/Sajidkbw/mcino-Introduction-to-Git-and-GitHub | jq -r '.parent.clone_url'
+https://github.com/ibm-developer-skills-network/mcino-Introduction-to-Git-and-GitHub.git


### PR DESCRIPTION
This PR reverts the previous footer update from 2022 to 2023 back to 2022 as part of the lab exercise.