### PR TITLE
Update copyright year in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
Revert du commit d1156c8 qui avait changé l'année de copyright de 2022 à 2023