### PR TITLE
Revert typo in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2023 XYZ, Inc._
+_© 2022 XYZ, Inc._

--- a/merge_branches.txt
+++ b/merge_branches.txt
@@ -1,0 +1,132 @@
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder
+$ touch simple-interest.sh
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder
+$ git init
+Initialized empty Git repository in E:/New folder/.git/
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder (main)
+$ git add simple-interest.sh
+warning: in the working copy of 'simple-interest.sh', LF will be replaced by CRLF the next time Git touches it
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder (main)
+$ git commit -m "Added simple-interest.sh script"
+[main (root-commit) f7ca8fb] Added simple-interest.sh script
+ 1 file changed, 28 insertions(+)
+ create mode 100644 simple-interest.sh
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder (main)
+$ git remote -v
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder (main)
+$ git remote add origin https://github.com/HRUSHIKESHA-irl/github-final-project.git
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder (main)
+$ git push -u origin main
+To https://github.com/HRUSHIKESHA-irl/github-final-project.git
+ ! [rejected]        main -> main (non-fast-forward)
+error: failed to push some refs to 'https://github.com/HRUSHIKESHA-irl/github-final-project.git'
+hint: Updates were rejected because the tip of your current branch is behind
+hint: its remote counterpart. If you want to integrate the remote changes,
+hint: use 'git pull' before pushing again.
+hint: See the 'Note about fast-forwards' in 'git push --help' for details.
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder (main)
+$ git pull origin main --rebase
+From https://github.com/HRUSHIKESHA-irl/github-final-project
+ * branch            main       -> FETCH_HEAD
+Successfully rebased and updated refs/heads/main.
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder (main)
+$ git push origin main
+Enumerating objects: 4, done.
+Counting objects: 100% (4/4), done.
+Delta compression using up to 8 threads
+Compressing objects: 100% (3/3), done.
+Writing objects: 100% (3/3), 628 bytes | 628.00 KiB/s, done.
+Total 3 (delta 1), reused 0 (delta 0), pack-reused 0 (from 0)
+remote: Resolving deltas: 100% (1/1), completed with 1 local object.
+To https://github.com/HRUSHIKESHA-irl/github-final-project.git
+   97eb58f..4be28fc  main -> main
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder (main)
+$ git clone https://github.com/HRUSHIKESHA-irl/mcino-Introduction-to-Git-and-GitHub.git
+Cloning into 'mcino-Introduction-to-Git-and-GitHub'...
+remote: Enumerating objects: 35, done.
+remote: Total 35 (delta 0), reused 0 (delta 0), pack-reused 35 (from 1)
+Receiving objects: 100% (35/35), 17.29 KiB | 769.00 KiB/s, done.
+Resolving deltas: 100% (7/7), done.
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder (main)
+$ cd mcino-Introduction-to-Git-and-GitHub
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder/mcino-Introduction-to-Git-and-GitHub (main)
+$ git branch
+* main
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder/mcino-Introduction-to-Git-and-GitHub (main)
+$ git checkout -b bug-fix-typo
+Switched to a new branch 'bug-fix-typo'
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder/mcino-Introduction-to-Git-and-GitHub (bug-fix-typo)
+$ code README.md
+
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder/mcino-Introduction-to-Git-and-GitHub (bug-fix-typo)
+$ git status
+On branch bug-fix-typo
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git restore <file>..." to discard changes in working directory)
+        modified:   README.md
+
+no changes added to commit (use "git add" and/or "git commit -a")
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder/mcino-Introduction-to-Git-and-GitHub (bug-fix-typo)
+$ git add README.md
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder/mcino-Introduction-to-Git-and-GitHub (bug-fix-typo)
+$ git commit -m "Fix typo: update footer from 2022 to 2023"
+[bug-fix-typo 3437351] Fix typo: update footer from 2022 to 2023
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder/mcino-Introduction-to-Git-and-GitHub (bug-fix-typo)
+$ git push origin bug-fix-typo
+Enumerating objects: 5, done.
+Counting objects: 100% (5/5), done.
+Delta compression using up to 8 threads
+Compressing objects: 100% (3/3), done.
+Writing objects: 100% (3/3), 337 bytes | 84.00 KiB/s, done.
+Total 3 (delta 2), reused 0 (delta 0), pack-reused 0 (from 0)
+remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
+remote:
+remote: Create a pull request for 'bug-fix-typo' on GitHub by visiting:
+remote:      https://github.com/HRUSHIKESHA-irl/mcino-Introduction-to-Git-and-GitHub/pull/new/bug-fix-typo
+remote:
+To https://github.com/HRUSHIKESHA-irl/mcino-Introduction-to-Git-and-GitHub.git
+ * [new branch]      bug-fix-typo -> bug-fix-typo
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder/mcino-Introduction-to-Git-and-GitHub (bug-fix-typo)
+$ git checkout main
+Switched to branch 'main'
+Your branch is up to date with 'origin/main'.
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder/mcino-Introduction-to-Git-and-GitHub (main)
+$ git pull origin main
+From https://github.com/HRUSHIKESHA-irl/mcino-Introduction-to-Git-and-GitHub
+ * branch            main       -> FETCH_HEAD
+Already up to date.
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder/mcino-Introduction-to-Git-and-GitHub (main)
+$ git merge bug-fix-typo
+Updating ad95b0a..3437351
+Fast-forward
+ README.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+hrush@HRUSHIKESHA MINGW64 /e/New folder/mcino-Introduction-to-Git-and-GitHub (main)
+$ git push origin main
+Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
+To https://github.com/HRUSHIKESHA-irl/mcino-Introduction-to-Git-and-GitHub.git
+   ad95b0a..3437351  main -> main


### PR DESCRIPTION
This pull request reverts the previous commit that updated the footer 
from "2022 XYZ, Inc." to "2023 XYZ, Inc." 
The README.md now correctly reflects "2022 XYZ, Inc."
