### PR TITLE
fix: update copyright year from 2022 to 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
Reverting the copyright year in README.md back from 2023 to 2022.