### PR TITLE
Fix typo: corrected Addtional to Additional in simple-interest.sh

### DIFF
--- a/simple-interest.sh
+++ b/simple-interest.sh
@@ -3,7 +3,7 @@
 # Do not use this in production. Sample purpose only.
 
 # Author: Upkar Lidder (IBM)
-# Addtional Authors:
+# Additional Authors:
 # <your Github username>
 
 # Input:


### PR DESCRIPTION
Fixed a typo in the comments section of simple-interest.sh file. Changed 'Addtional Authors' to 'Additional Authors'.