### PR TITLE
Fix typo and formula in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Input:
    t, time period in years
    r, annual rate of interest
 Output
-   simple interest = p*t*r
+   simple interest = (p*t*r)/100
 ```
 
-_© 2022 XYZ, Inc._
+_© 2022 IBM, Inc._


### PR DESCRIPTION
Fixed the simple interest formula from p*t*r to (p*t*r)/100 
and replaced XYZ with IBM in the copyright line.