### PR TITLE
Fix typo in markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._


### PR DESCRIPTION
Fixes a typo in the README: the simple interest formula should be p*t*r/100, not p*t*r.