### PR TITLE
Fix typo in README: add missing colon after Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Input:
    p, principal amount
    t, time period in years
    r, annual rate of interest
-Output
+Output:
    simple interest = p*t*r
 ```
 


### PR DESCRIPTION
This pull request fixes a small typo in the README where the 'Output' label was missing a colon.