### PR TITLE
Fix typo in simple-interest.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# Introduction to Git and GitHub
+# mcino-Introduction-to-Git-and-GitHub
 
 ## Simple Interest Calculator
 
-A calculator that calculates simple interest given principal, annual rate of interest and time period in years.
+**Project name:** mcino-Introduction-to-Git-and-GitHub
+**Maintained by:** NonomiyaIzumi
+
+This project is the final assignment for the *Getting Started with Git and GitHub* course. It contains a Bash command-line calculator that computes simple interest given a principal amount, an annual rate of interest, and a time period in years.
 
 ```
 Input:

--- a/simple-interest.sh
+++ b/simple-interest.sh
@@ -4,7 +4,7 @@
 
 # Author: Upkar Lidder (IBM)
 # Addtional Authors:
-# <your Github username>
+# NonomiyaIzumi
 
 # Input:
 # p, principal amount

--- a/simple-interest.sh
+++ b/simple-interest.sh
@@ -3,7 +3,7 @@
 # Do not use this in production. Sample purpose only.
 
 # Author: Upkar Lidder (IBM)
-# Addtional Authors:
+# Additional Authors:
 # NonomiyaIzumi
 
 # Input:


### PR DESCRIPTION
Fixes a typo: 'Addtional' -> 'Additional' in the authors comment of simple-interest.sh. Submitted as part of the Getting Started with Git and GitHub final project.