### PR TITLE
Fix author section formatting in simple-interest.sh

### DIFF
--- a/simple-interest.sh
+++ b/simple-interest.sh
@@ -3,9 +3,8 @@
 # Do not use this in production. Sample purpose only.
 
 # Author: Upkar Lidder (IBM)
-# Addtional Authors:
-# <your Github username>
-
+# Additional Authors:
+# enhbatenhee124-dev
 # Input:
 # p, principal amount
 # t, time period in years


### PR DESCRIPTION
This PR is submitted from the bug-fix-revert branch on my fork (enhbatenhee124-dev/mcino-Introduction-to-Git-and-GitHub) as part of the Introduction to Git and GitHub course final project. It fixes a typo ("Addtional" -> "Additional") and fills in the contributor username placeholder in simple-interest.sh.