### PR TITLE
Fix typo in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,4 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+


### PR DESCRIPTION
Fixed a typo in the LICENSE file