### PR TITLE
Revert typo fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2022 XYZ, Inc._
+_© 2023 XYZ, Inc._

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Output
    simple interest = p*t*r
 ```
 
-_© 2023 XYZ, Inc._
+_© 2022 XYZ, Inc._

--- a/merge_branches
+++ b/merge_branches
@@ -1,0 +1,9 @@
+git checkout main
+Switched to branch 'main'
+Your branch is up to date with 'origin/main'.
+
+git merge bug-fix-typo
+Updating ad95b0a..3b451e4
+Fast-forward
+ README.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)


### PR DESCRIPTION
Revert the previous typo fix in README.md and restore the original copyright year.